### PR TITLE
Update how the registration endpoint is generated

### DIFF
--- a/utils/maurice/locals.tf
+++ b/utils/maurice/locals.tf
@@ -1,6 +1,8 @@
 locals {
   base_offset               = length(substr(var.f5xc_api_url, 8, -1)) - 4
-  is_production_env         = endswith(var.f5xc_api_url, var.production_api_base)
-  maurice_endpoint_url      = local.is_production_env ? format("https://%s", replace(substr(substr(substr(var.f5xc_api_url, 8, -1), 0, local.base_offset), 0 - 23, -1), "console", "register")) : format("https://register.%s", substr(substr(substr(var.f5xc_api_url, 8, -1), 0, local.base_offset), 0 - 19, -1))
-  maurice_mtls_endpoint_url = local.is_production_env ? format("https://%s", replace(substr(substr(substr(var.f5xc_api_url, 8, -1), 0, local.base_offset), 0 - 23, -1), "console", "register-tls")) : format("https://register-tls.%s", substr(substr(substr(var.f5xc_api_url, 8, -1), 0, local.base_offset), 0 - 19, -1))
+  tenant_id                 = split(".", substr(var.f5xc_api_url, 8, -1))[0]
+  base_domain_list          = split(".", split("/", substr(var.f5xc_api_url, 8, -1))[0])
+  base_domain               = join(".", slice(local.base_domain_list, 1, length(local.base_domain_list)))
+  maurice_endpoint_url      = format("https://register.%s.%s", local.tenant_id, local.base_domain)
+  maurice_mtls_endpoint_url = format("https://register-tls.%s.%s", local.tenant_id, local.base_domain)
 }

--- a/utils/maurice/locals.tf
+++ b/utils/maurice/locals.tf
@@ -1,8 +1,7 @@
 locals {
   base_offset               = length(substr(var.f5xc_api_url, 8, -1)) - 4
-  tenant_id                 = split(".", substr(var.f5xc_api_url, 8, -1))[0]
   base_domain_list          = split(".", split("/", substr(var.f5xc_api_url, 8, -1))[0])
   base_domain               = join(".", slice(local.base_domain_list, 1, length(local.base_domain_list)))
-  maurice_endpoint_url      = format("https://register.%s.%s", local.tenant_id, local.base_domain)
-  maurice_mtls_endpoint_url = format("https://register-tls.%s.%s", local.tenant_id, local.base_domain)
+  maurice_endpoint_url      = format("https://register.%s", local.base_domain)
+  maurice_mtls_endpoint_url = format("https://register-tls.%s", local.base_domain)
 }


### PR DESCRIPTION
It's a bit hard to read how the registration endpoint is built today. This simplifies that, and works across multiple environments.

I am an F5 employee, so hopefully that will make accepting this PR easy :)